### PR TITLE
[WIP] Test

### DIFF
--- a/phonenumber.rb
+++ b/phonenumber.rb
@@ -1,0 +1,47 @@
+#Prepare CLI for evaluation - remove spaces and divide by character
+b = ARGV.join('').chars
+
+#Remove all special characters except for '-'
+b.map {|g| g.gsub!(/[^0-9A-Za-z-]/, '')}
+
+#Verify array elements and swap   
+repl = {
+    'A' => 2,
+    'B' => 2,
+    'C' => 2,
+
+    'D' => 3,
+    'E' => 3,
+    'F' => 3,
+
+    'G' => 4,
+    'H' => 4,
+    'I' => 4,
+
+    'J' => 5,
+    'K' => 5,
+    'L' => 5,
+
+    'M' => 6,
+    'N' => 6,
+    'O' => 6,
+
+    'P' => 7,
+    'Q' => 7,
+    'R' => 7,
+    'S' => 7,
+
+    'T' => 8,
+    'U' => 8,
+    'V' => 8,
+
+    'W' => 9,
+    'X' => 9,
+    'Y' => 9,
+    'Z' => 9,
+}
+c = b.map! do |e| repl.fetch(e,e)
+end
+
+#Print it on screen
+puts c.join('')

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,17 @@
+require 'test/unit'
+require_relative 'phonenumber'
+
+class TestPhoneNumberConverter < Test::Unit::TestCase
+
+    def setup
+        @phonenumber = phonenumber.new
+    end
+
+    def testjoin
+        assert_equal "1-800-FLAWER", @phonenumber.testjoin("1-800-FL AWER")
+    end
+    
+    def testreplace
+        assert_equal "222-333-444-555-666-7777-888-9999", @phonenumber.testreplace("ABC-DEF-GHI-JKL-MNO-PQRS-TUV-WXYZ")
+    end
+end


### PR DESCRIPTION
Testy nie zawierają unitu dotyczącego pomijania znaków specjalnych. Nadto nie pobierają wartości instance variable. 

test.rb:7:in `setup'
Error: testjoin(TestPhoneNumberConverter): NameError: undefined local variable or method `phonenumber' for #<TestPhoneNumberConverter:0x0000558c436a1600>
========================================================================================
E
========================================================================================
test.rb:7:in `setup'
Error: testreplace(TestPhoneNumberConverter): NameError: undefined local variable or method `phonenumber' for #<TestPhoneNumberConverter:0x0000558c436a13d0>
========================================================================================

Finished in 0.013497742 seconds.
----------------------------------------------------------------------------------------
2 tests, 0 assertions, 0 failures, 2 errors, 0 pendings, 0 omissions, 0 notifications
0% passed